### PR TITLE
WIP: Use head request instead get request

### DIFF
--- a/hhhash/create.py
+++ b/hhhash/create.py
@@ -5,7 +5,7 @@ import hashlib
 def buildhash(url=None, debug=False):
     if url is None:
         return False
-    r = requests.get(url)
+    r = requests.head(url)
     hhhash = ""
     for header in r.headers.keys():
         hhhash = f"{hhhash}:{header}"


### PR DESCRIPTION
For calculating hashes this should be enough. Also, this keeps the response size small.